### PR TITLE
fix homepage property

### DIFF
--- a/ios/RNCheckNotificationPermission.podspec
+++ b/ios/RNCheckNotificationPermission.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNCheckNotificationPermission
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/duongxuannam/react-native-check-notification-permission"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
Set homepage property within RNCheckNotificationPermission.podspec file.

Without this property set correctly, I experimented with problems executing 'pod install'.

To have a better reference, this was the problem:
```
[!] The `RNCheckNotificationPermission` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```