### PR TITLE
Fixed problem of missing homepage parameter in podfile

### DIFF
--- a/ios/RNCheckNotificationPermission.podspec
+++ b/ios/RNCheckNotificationPermission.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNCheckNotificationPermission
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/duongxuannam/react-native-check-notification-permission"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
This would fix the problem of issue #4 
All it adds is a homepage string (URL of this repository) for the homepage parameter in the profile. 
Would be nice if this was added otherwise users of this library have to edit their files themself.  